### PR TITLE
Accept NSString and NSURL for NSLinkAttributeName

### DIFF
--- a/Ashton/AshtonAppKit.m
+++ b/Ashton/AshtonAppKit.m
@@ -83,7 +83,11 @@
                 newAttrs[AshtonAttrStrikethroughColor] = [self arrayForColor:attr];
             }
             if ([attrName isEqual:NSLinkAttributeName]) {
-                newAttrs[AshtonAttrLink] = [attr absoluteString];
+				if ([attr isKindOfClass:[NSURL class]]) {
+					newAttrs[AshtonAttrLink] = [attr absoluteString];
+				} else if ([attr isKindOfClass:[NSString class]]) {
+					newAttrs[AshtonAttrLink] = attr;
+				}
             }
         }
         [output setAttributes:newAttrs range:range];


### PR DESCRIPTION
This crashed previously because it assumed `attr` to be an `NSURL`, when `NSAttributedString` accepts both NSString and NSURL as valid values for `NSLinkAttributeName`.
