### PR TITLE
Include the font size as an attribute in the cache key

### DIFF
--- a/Ashton/AshtonUtils.m
+++ b/Ashton/AshtonUtils.m
@@ -6,7 +6,8 @@
 + (id)CTFontRefWithFamilyName:(NSString *)familyName postScriptName:(NSString *)postScriptName size:(CGFloat)pointSize boldTrait:(BOOL)isBold italicTrait:(BOOL)isItalic features:(NSArray *)features {
 
     NSMutableDictionary *cache = [self fontsCache];
-    NSMutableDictionary *descriptorAttributes = [NSMutableDictionary dictionaryWithCapacity:2];
+    NSMutableDictionary *descriptorAttributes = [NSMutableDictionary dictionaryWithCapacity:3];
+    descriptorAttributes[(id)kCTFontSizeAttribute] = @(pointSize);
     if (familyName) descriptorAttributes[(id)kCTFontNameAttribute] = familyName;
     if (postScriptName) descriptorAttributes[(id)kCTFontNameAttribute] = postScriptName;
 


### PR DESCRIPTION
The caching introduced to speed up Ashton has a small bug, it ignores the font size for the cache key. this should fix it s.t. we get correct fonts.