### PR TITLE
Use NSString + NSRange instead of swift.string + range

### DIFF
--- a/Sources/Ashton/AshtonHTMLWriter.swift
+++ b/Sources/Ashton/AshtonHTMLWriter.swift
@@ -25,20 +25,21 @@ final class AshtonHTMLWriter {
             var paragraphContent = String()
             let nsParagraphRange = NSRange(paragraphRange, in: string)
             var paragraphTag = HTMLTag(defaultName: .p, attributes: [:], ignoreParagraphStyles: false)
+            // We use `attributedString.string as NSString` casts and NSRange ranges in the block because
+            // we experienced outOfBounds crashes when converting NSRange to Range and using it on swift string
             attributedString.enumerateAttributes(in: nsParagraphRange,
                                                  options: .longestEffectiveRangeNotRequired, using: { attributes, nsrange, _ in
                                                     let paragraphStyle = attributes.filter { $0.key == .paragraphStyle }
                                                     paragraphTag.addAttributes(paragraphStyle)
 
+                                                    let nsString = attributedString.string as NSString
                                                     if nsParagraphRange.length == nsrange.length {
-                                                        let nsString = attributedString.string as NSString
                                                         paragraphTag.addAttributes(attributes)
                                                         paragraphContent += String(nsString.substring(with: nsrange)).htmlEscaped
                                                     } else {
-                                                        let string = attributedString.string as NSString
                                                         var tag = HTMLTag(defaultName: .span, attributes: attributes, ignoreParagraphStyles: true)
                                                         paragraphContent += tag.parseOpenTag()
-                                                        paragraphContent += String(string.substring(with: nsrange)).htmlEscaped
+                                                        paragraphContent += String(nsString.substring(with: nsrange)).htmlEscaped
                                                         paragraphContent += tag.makeCloseTag()
                                                     }
             })

--- a/Sources/Ashton/AshtonHTMLWriter.swift
+++ b/Sources/Ashton/AshtonHTMLWriter.swift
@@ -31,8 +31,9 @@ final class AshtonHTMLWriter {
                                                     paragraphTag.addAttributes(paragraphStyle)
 
                                                     if nsParagraphRange.length == nsrange.length {
+                                                        let nsString = attributedString.string as NSString
                                                         paragraphTag.addAttributes(attributes)
-                                                        paragraphContent += String(attributedString.string[paragraphRange]).htmlEscaped
+                                                        paragraphContent += String(nsString.substring(with: nsrange)).htmlEscaped
                                                     } else {
                                                         let string = attributedString.string as NSString
                                                         var tag = HTMLTag(defaultName: .span, attributes: attributes, ignoreParagraphStyles: true)


### PR DESCRIPTION
For certain asian characters using `attributedString.string[paragraphRange])` leads to an out-of-bounds exception with. 
![Screenshot 2019-10-02 at 15 09 35](https://user-images.githubusercontent.com/610520/66046750-addd7300-e526-11e9-9131-ae4376f6f559.png)

This PR resolves this by using NSString range operations instead of the String + Range
