### PR TITLE
Fix implicit newline handling after <p> tag

### DIFF
--- a/Sources/Ashton/AshtonHTMLWriter.swift
+++ b/Sources/Ashton/AshtonHTMLWriter.swift
@@ -25,7 +25,6 @@ public final class AshtonHTMLWriter {
     public func encode(_ attributedString: NSAttributedString) -> Ashton.HTML {
         let string = attributedString.string
         let paragraphRanges = self.getParagraphRanges(from: string)
-        let fullInputStringLength = (string as NSString).length
         var html = String()
         for paragraphRange in paragraphRanges {
             var paragraphContent = String()
@@ -33,8 +32,11 @@ public final class AshtonHTMLWriter {
             var paragraphTag = HTMLTag(defaultName: .p, attributes: [:], ignoreParagraphStyles: false)
 
             // We add an additional character to the paragraph range to get the parsed paragraph separator (e.g \n)
-            if fullInputStringLength >= nsParagraphRange.upperBound + 1 {
-                nsParagraphRange.length = nsParagraphRange.length + 1
+            if paragraphRange.isEmpty && paragraphRanges.count > 0 && paragraphRange == paragraphRanges.last {
+                let fullInputStringLength = (string as NSString).length
+                if fullInputStringLength >= nsParagraphRange.upperBound + 1 {
+                    nsParagraphRange.length = nsParagraphRange.length + 1
+                }
             }
             // We use `attributedString.string as NSString` casts and NSRange ranges in the block because
             // we experienced outOfBounds crashes when converting NSRange to Range and using it on swift string

--- a/Tests/AshtonTests.swift
+++ b/Tests/AshtonTests.swift
@@ -60,6 +60,15 @@ class AshtonTests: XCTestCase {
         XCTAssertEqual(attributedString, roundTripAttributedString)
     }
 
+    func testRoundtrippingEmptyString() {
+        let string = ""
+        let attributedString = NSAttributedString(string: string)
+        let html = Ashton.encode(attributedString)
+
+        let roundTripAttributedString = Ashton.decode(html)
+        XCTAssertEqual(attributedString, roundTripAttributedString)
+    }
+
     func testNewlineAfterParagraph() {
         let html = "<p style=\'color: rgba(0, 0, 0, 1.000000); font: 24px \"Avenir Next\"; text-align: center; -cocoa-font-postscriptname: \"AvenirNext-Medium\"; \'>Line1</p><p style=\'color: rgba(0, 0, 0, 1.000000); font: 24px \"Avenir Next\"; text-align: center; -cocoa-font-postscriptname: \"AvenirNext-Medium\"; \'>Line2</p><p style=\'color: rgba(0, 0, 0, 1.000000); font: 24px \"Avenir Next\"; text-align: center; -cocoa-font-postscriptname: \"AvenirNext-Medium\"; \'>Line3</p>"
         let attributedString = Ashton.decode(html)

--- a/Tests/AshtonTests.swift
+++ b/Tests/AshtonTests.swift
@@ -46,10 +46,17 @@ class AshtonTests: XCTestCase {
         let string = "\n\nHello World,\n\n\nwith trailing whitespace\n\n\n"
         let attributedString = NSAttributedString(string: string)
         let html = Ashton.encode(attributedString)
-        print(html)
 
         let roundTripAttributedString = Ashton.decode(html)
-        print("|\(roundTripAttributedString.string)|")
+        XCTAssertEqual(attributedString, roundTripAttributedString)
+    }
+
+    func testPersistenceOfMultipleNewlines() {
+        let string = "\n\n\n\n\n"
+        let attributedString = NSAttributedString(string: string)
+        let html = Ashton.encode(attributedString)
+
+        let roundTripAttributedString = Ashton.decode(html)
         XCTAssertEqual(attributedString, roundTripAttributedString)
     }
 

--- a/Tests/AshtonTests.swift
+++ b/Tests/AshtonTests.swift
@@ -43,12 +43,18 @@ class AshtonTests: XCTestCase {
     }
 
     func testRoundTripWithNewlines() {
-        let string = "\n\nHello World,\n\n\n\nwith trailing whitespace\n\n\n"
+        let string = "\n\nHello World,\n\n\nwith trailing whitespace\n\n\n"
         let attributedString = NSAttributedString(string: string)
         let html = Ashton.encode(attributedString)
 
         let roundTripAttributedString = Ashton.decode(html)
         XCTAssertEqual(attributedString, roundTripAttributedString)
+    }
+
+    func testNewlineAfterParagraph() {
+        let html = "<p style=\'color: rgba(0, 0, 0, 1.000000); font: 24px \"Avenir Next\"; text-align: center; -cocoa-font-postscriptname: \"AvenirNext-Medium\"; \'>Line1</p><p style=\'color: rgba(0, 0, 0, 1.000000); font: 24px \"Avenir Next\"; text-align: center; -cocoa-font-postscriptname: \"AvenirNext-Medium\"; \'>Line2</p><p style=\'color: rgba(0, 0, 0, 1.000000); font: 24px \"Avenir Next\"; text-align: center; -cocoa-font-postscriptname: \"AvenirNext-Medium\"; \'>Line3</p>"
+        let attributedString = Ashton.decode(html)
+        print(attributedString.string)
     }
 
     func testStyleTagsOrdering() {

--- a/Tests/AshtonTests.swift
+++ b/Tests/AshtonTests.swift
@@ -46,15 +46,17 @@ class AshtonTests: XCTestCase {
         let string = "\n\nHello World,\n\n\nwith trailing whitespace\n\n\n"
         let attributedString = NSAttributedString(string: string)
         let html = Ashton.encode(attributedString)
+        print(html)
 
         let roundTripAttributedString = Ashton.decode(html)
+        print("|\(roundTripAttributedString.string)|")
         XCTAssertEqual(attributedString, roundTripAttributedString)
     }
 
     func testNewlineAfterParagraph() {
         let html = "<p style=\'color: rgba(0, 0, 0, 1.000000); font: 24px \"Avenir Next\"; text-align: center; -cocoa-font-postscriptname: \"AvenirNext-Medium\"; \'>Line1</p><p style=\'color: rgba(0, 0, 0, 1.000000); font: 24px \"Avenir Next\"; text-align: center; -cocoa-font-postscriptname: \"AvenirNext-Medium\"; \'>Line2</p><p style=\'color: rgba(0, 0, 0, 1.000000); font: 24px \"Avenir Next\"; text-align: center; -cocoa-font-postscriptname: \"AvenirNext-Medium\"; \'>Line3</p>"
         let attributedString = Ashton.decode(html)
-        print(attributedString.string)
+        XCTAssertEqual(attributedString.string, "Line1\nLine2\nLine3")
     }
 
     func testStyleTagsOrdering() {


### PR DESCRIPTION
#44 changed the newline handling after paragraphs to explicitly encode the newlines as `<br />` tags into the content of the `<p>` tag. Before that we implicitly added a newline between two paragraphs when parsing the html. The change of encoding an explicit  `<br />` led to inconsistencies when parsing html encoded with previous Ashton versions. This PR reverts the newline handling between paragraphs to use an implicit newline to stay compatible with previous html. It still fixes the trailing newline issue (from #44) by explicitly writing the newline into the html for a trailing empty paragraph.