### PR TITLE
Fix format of privacy manifest

### DIFF
--- a/Sources/Ashton/Resources/PrivacyInfo.xcprivacy
+++ b/Sources/Ashton/Resources/PrivacyInfo.xcprivacy
@@ -2,20 +2,13 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>NSPrivacyTracking</key>
+	<false/>
 	<key>NSPrivacyCollectedDataTypes</key>
-	<array>
-		<dict>
-			<key>NSPrivacyCollectedDataType</key>
-			<string></string>
-			<key>NSPrivacyCollectedDataTypeLinked</key>
-			<false/>
-			<key>NSPrivacyCollectedDataTypeTracking</key>
-			<false/>
-			<key>NSPrivacyCollectedDataTypePurposes</key>
-			<array>
-				<string></string>
-			</array>
-		</dict>
-	</array>
+	<array/>
+	<key>NSPrivacyTrackingDomains</key>
+	<array/>
+	<key>NSPrivacyAccessedAPITypes</key>
+	<array/>
 </dict>
 </plist>


### PR DESCRIPTION
The format of the Ashton privacy manifest is invalid.
I was made aware that some keys are missing and that the nesting is wrong [in another project](https://github.com/weichsel/ZIPFoundation/pull/314).